### PR TITLE
Stream search windows from tables for match template

### DIFF
--- a/docs/programs/constrained_search.md
+++ b/docs/programs/constrained_search.md
@@ -9,6 +9,43 @@ The constrained search program takes in locations and orientations for one parti
 This allows us to perform for fewer cross correlations, reducing the noise and thus increasing our sensitivity.
 This increased sensitivity is incredibly useful when searching for smaller proteins which may associate with a larger complex but otherwise fall below the noise floor of full-orientation 2DTM.
 
+## Step-by-step workflow
+
+1. **Identify the reference particle with full-orientation 2DTM.** Run the
+   [match template program](match_template.md) on each micrograph to localise the
+   large reference complex.  If the approximate positions of the target partner
+   are known you can accelerate this step by enabling the
+   [`search_windows`](match_template.md#restricting-the-search-to-regions-of-interest)
+   option introduced in this update.  When thousands of coordinates are
+   available, point the configuration at a CSV/Parquet/Feather table using
+   `search_window_table_path` to stream the windows instead of listing them
+   individually.
+2. **Refine the reference particle poses.** Use the standard refine-template
+   program on the match-template peaks to produce high-confidence orientations
+   and defocus values for the reference particle.  The constrained search reuses
+   these parameters directly.
+3. **Prepare particle stacks.** Export the refined reference particle table to a
+   CSV file and duplicate it for the constrained particle.  The constrained copy
+   will ultimately hold the second particle’s statistics; only the
+   `correlation_average_path` and `correlation_variance_path` columns are used as
+   inputs at this stage.  Ensure each stack contains particles from a *single*
+   micrograph—constrained search currently operates on one micrograph at a time.
+4. **Determine the relative geometry between the particles.** Simulate or align
+   two PDB models representing the reference and constrained particles and use
+   the helper scripts in `programs/constrained_search/utils/` (for example
+   `get_center_vector.py` and `get_rot_axis.py`) to measure the centre offset and
+   rotation axis.
+5. **Populate the YAML configuration.** Edit the example configuration provided
+   in `programs/constrained_search/constrained_search_example_config.yaml` with
+   the paths and numerical values extracted in the previous steps.
+6. **Execute the program.** Launch the driver script
+   `programs/constrained_search/run_constrained_search.py` after updating the
+   `YAML_CONFIG_PATH` and `DATAFRAME_OUTPUT_PATH` constants.  The script prints
+   the z-score threshold corresponding to your requested false-positive rate and
+   writes both the full results and an above-threshold CSV to disk.
+
+The following sections describe each configuration block in more detail.
+
 ## Configuration options
 
 A default config file for the constrained search program is available [here on the GitHub page](https://raw.githubusercontent.com/Lucaslab-Berkeley/Leopard-EM/refs/heads/main/programs/constrained_search/constrained_search_example_config.yaml).
@@ -86,6 +123,25 @@ orientation_refinement_config:
 ### Pre-processing filters and computational config
 
 These should be the same as for [Match Template](../programs/match_template.md).
+
+## Output files and interpretation
+
+The driver script saves three artefacts:
+
+- `*_constrained.csv` — the full per-particle table containing refined
+  positions (`refined_pos_x_img`, `refined_pos_y_img`), orientations, relative
+  defocus, and the correlation statistics required for downstream filtering.
+- `*_constrained_above_threshold.csv` — a filtered subset that keeps only rows
+  whose z-score exceeds the automatically determined noise-floor threshold.  This
+  file is convenient when visualising likely hits.
+- `*_constrained_parameters.csv` — metadata recording the number of defocus
+  planes, orientations, pixels searched, and the z-score threshold used.  Keep
+  this alongside the particle table for reproducibility.
+
+Inspect the refined MIP and z-score values to validate that the constrained
+search improved the signal relative to the initial full-orientation run.  When a
+second pass over the same micrograph is required, start from the original match
+template CSV to avoid duplicating detections.
 
 
 

--- a/docs/programs/match_template.md
+++ b/docs/programs/match_template.md
@@ -198,7 +198,59 @@ df = mt_manager.results_to_dataframe(locate_peaks_kwargs={"false_positives": 1.0
 
 # Uses a pre-defined z-score cutoff for peak calling
 df = mt_manager.results_to_dataframe(locate_peaks_kwargs={"z_score_cutoff": 7.8})
+
 ```
+
+## Restricting the search to regions of interest
+
+When the approximate particle locations are known *a priori* you can instruct the
+match template program to evaluate correlations only within specific spatial
+windows.  Limiting the search domain reduces the number of cross-correlations that
+must be computed and consequently lowers the noise floor of the z-score map.  This
+behaviour is configured through the optional `search_windows` block in the YAML
+configuration file:
+
+```yaml
+search_windows:
+  - center_y_img: 2048.0
+    center_x_img: 1984.0
+    half_height: 64
+    half_width: 96
+```
+
+Each entry defines a rectangular region on the valid correlation grid centred on a
+known particle coordinate.  The `half_height` (and optional `half_width`) values are
+expressed in units of *valid* pixels; the code automatically extends the extracted
+micrograph patch so that all valid placements of the template within that window are
+considered.  You may provide multiple windows to search several particles in the
+same micrograph.
+
+When the list of coordinates is very large you can also stream the window
+definitions from a tabular file using the `search_window_table_path` option.  CSV,
+Parquet, and Feather formats are supported; only the three columns
+`center_y_img`, `center_x_img`, and `half_height` are required, with `half_width`
+remaining optional.  For example, a configuration that streams windows from a CSV
+file in batches of 500 rows would look like:
+
+```yaml
+search_window_table_path: /path/to/windows.csv
+search_window_table_format: auto  # optional, inferred from the suffix
+search_window_chunk_size: 500      # number of CSV rows to load per batch
+```
+
+If both `search_windows` and `search_window_table_path` are provided the explicit
+list takes precedence.  The CSV reader is chunked so that millions of coordinates
+can be processed without exceeding host memory; Parquet and Feather inputs are
+loaded eagerly because pandas does not expose streaming readers for these
+formats.
+
+Only the `run_match_template` entry point supports constrained windows at this
+time—distributed execution raises an informative error.  Outside the configured
+regions the MIP and z-score maps are filled with `-inf`, ensuring that the automatic
+peak picking ignores unsearched pixels.  The `MatchTemplateManager` also adjusts the
+default z-score cutoff so that the expected number of false positives corresponds to
+the reduced number of pixels that were inspected; custom `locate_peaks_kwargs`
+continue to work as before.
 
 Currently, Leopard-EM uses a false-positive rate of 1 per micrograph by default to differentiate between true particles and background.
 

--- a/docs/tutorials/constrained_search_workflow.md
+++ b/docs/tutorials/constrained_search_workflow.md
@@ -1,0 +1,105 @@
+---
+title: Constrained Search Workflow
+description: End-to-end guide for running Leopard-EM's constrained search with optional windowed 2DTM
+---
+
+# Constrained search workflow
+
+This tutorial walks through the practical steps required to detect a secondary
+particle that sits next to a larger reference complex.  The procedure combines
+three major stages:
+
+1. Perform a standard 2DTM search to locate the reference particle.  The new
+   `search_windows` option allows you to restrict the initial search to small
+   regions when approximate target coordinates are known, significantly reducing
+   runtime.
+2. Refine the reference particle’s pose and assemble particle stacks containing
+   both the reference and constrained locations.
+3. Execute the constrained-search program to evaluate a tiny orientation and
+   translation grid around the predicted partner location.
+
+Each stage is described in detail below with links to the relevant program
+documentation.
+
+## 1. Locate the reference particle
+
+1. Generate a match-template configuration for the micrograph of interest.  The
+   fields are identical to those described in the
+   [match template program reference](../programs/match_template.md).
+2. If a rough estimate of the constrained particle’s position is available,
+   enable the optional `search_windows` block in the configuration.  The window
+   size is expressed in valid correlation pixels (number of possible template
+   centres) and automatically accounts for template padding.  Multiple windows
+   can be specified when searching for several candidate sites on the same
+   micrograph.  Large coordinate lists can be streamed from a CSV/Parquet/Feather
+   file via `search_window_table_path`, which keeps memory usage flat by loading
+   chunks of positions at a time.
+3. Run `programs/match_template/run_match_template.py` and export the peaks to a
+   CSV using `MatchTemplateManager.results_to_dataframe`.  Keep the output MRC
+   statistic maps; they provide the correlation mean and variance used later in
+   the workflow.
+
+## 2. Refine the reference particle
+
+1. Use the refine-template program on the match-template detections to obtain
+   precise orientations and defocus values for the reference particle.  This
+   step removes false positives and produces the per-particle data that the
+   constrained search consumes.
+2. Save the refined table as `reference_particles.csv`.  Create a duplicate file
+   named `constrained_particles.csv`; this copy will store the constrained
+   search results.  At this stage only the `correlation_average_path` and
+   `correlation_variance_path` columns are needed, but retaining the other
+   columns simplifies downstream analysis.
+3. Use the helper scripts in
+   `programs/constrained_search/utils/` to determine the geometric relationship
+   between the particles:
+   - `get_center_vector.py` produces the vector from the reference particle to
+     the constrained particle when both models are in their default orientation.
+   - `get_rot_axis.py` estimates the relative rotation axis if the complex
+     exhibits rotational motion.
+
+## 3. Configure the constrained search
+
+1. Copy `programs/constrained_search/constrained_search_example_config.yaml`
+   into your working directory and update the fields:
+   - `template_volume_path` should point to the simulated volume of the
+     constrained particle (not the reference template used for match template).
+   - `center_vector` is filled with the values produced by
+     `get_center_vector.py`.
+   - `particle_stack_reference` and `particle_stack_constrained` reference the
+     two CSV files created in the previous step.  Ensure the `extracted_box_size`
+     values are only slightly larger than the template to keep the search grid
+     compact.
+   - Edit the `orientation_refinement_config` according to the expected motion
+     of the constrained particle.  Tight angular limits maximise sensitivity.
+2. Adjust the computational settings (GPU IDs and CPU stream count) in the
+   `computational_config` block.
+
+## 4. Run the constrained search
+
+Execute `programs/constrained_search/run_constrained_search.py` after setting the
+`YAML_CONFIG_PATH` and `DATAFRAME_OUTPUT_PATH` constants.  The script loads the
+configuration, applies the preprocessing filters, and evaluates the small search
+grid for each particle in the reference stack.  Upon completion it prints the
+z-score threshold corresponding to the requested false-positive rate and writes
+three files:
+
+- `<output>.csv` — the full constrained-search table.
+- `<output>_above_threshold.csv` — rows whose `refined_scaled_mip` exceeds the
+  Gaussian-noise threshold.
+- `<output>_parameters.csv` — metadata describing the number of projections and
+  pixels evaluated; keep this file for reproducibility.
+
+## 5. Inspect and iterate
+
+Open the `_above_threshold` CSV in your favourite analysis tool to review the
+hits.  High z-scores concentrated around the expected coordinates indicate a
+successful constrained search.  Because the search space is tiny, the results are
+highly sensitive to errors in the centre vector and orientation offsets—if no
+hits are recovered, revisit the geometry and consider widening the angular or
+positional ranges before re-running the program.
+
+This pipeline can be repeated micrograph by micrograph.  Automating the process
+is straightforward: iterate through the list of match-template outputs, generate
+per-micrograph constrained search configurations, and aggregate the resulting
+CSV files for downstream structural analysis.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
     - 2DTM Introduction:      tutorials/match_template_intro.md
     - Batch Processing:       tutorials/batch_processing.md
     - Distributed Computing:  tutorials/distributed_match_template.md
+    - Constrained Search Workflow: tutorials/constrained_search_workflow.md
   - Examples:
     - Match Template Config:            examples/01_basic_configuration.ipynb
     - Peaks to DataFrame:               examples/02_extract_peak_info.ipynb

--- a/programs/match_template/match_template_example_config.yaml
+++ b/programs/match_template/match_template_example_config.yaml
@@ -50,3 +50,13 @@ computational_config:
   gpu_ids:
   - 0
   num_cpus: 1
+# Optional: limit the 2DTM search to specific windows around known coordinates.
+# search_windows:
+#   - center_y_img: 2048.0
+#     center_x_img: 1984.0
+#     half_height: 64   # search +/- 64 valid pixels vertically
+#     half_width: 96    # override horizontal extent (defaults to half_height)
+# Alternatively, stream large coordinate lists from a tabular file.
+# search_window_table_path: /some/path/to/windows.csv
+# search_window_table_format: auto   # csv/parquet/feather (auto uses file suffix)
+# search_window_chunk_size: 500      # rows per CSV chunk; ignored for other formats

--- a/src/leopard_em/pydantic_models/data_structures/__init__.py
+++ b/src/leopard_em/pydantic_models/data_structures/__init__.py
@@ -2,8 +2,11 @@
 
 from .optics_group import OpticsGroup
 from .particle_stack import ParticleStack
+from .search_window import SearchWindow, iter_search_windows_from_table
 
 __all__ = [
     "ParticleStack",
     "OpticsGroup",
+    "SearchWindow",
+    "iter_search_windows_from_table",
 ]

--- a/src/leopard_em/pydantic_models/data_structures/search_window.py
+++ b/src/leopard_em/pydantic_models/data_structures/search_window.py
@@ -1,0 +1,217 @@
+"""Definition of regions that constrain the match template search grid."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Annotated, Iterator, Literal
+
+import pandas as pd
+from pydantic import Field
+
+from leopard_em.pydantic_models.custom_types import BaseModel2DTM
+
+
+class SearchWindow(BaseModel2DTM):
+    """Spatial window limiting where match_template evaluates correlations.
+
+    The window is defined in image pixel coordinates using the template-centred
+    convention that is used throughout the match template pipeline.  The
+    half-width and half-height values describe how far away from the provided
+    centre (in pixels) the search should extend when evaluating candidate
+    positions.  The final search domain is expressed in the *valid* correlation
+    grid where the template lies completely inside the micrograph.
+
+    Parameters
+    ----------
+    center_y_img : float
+        Vertical pixel coordinate of the particle centre in the micrograph.
+    center_x_img : float
+        Horizontal pixel coordinate of the particle centre in the micrograph.
+    half_height : int
+        Number of valid correlation pixels to include above and below the
+        centre.  A value of zero restricts the search to a single pixel in the
+        vertical direction.
+    half_width : int, optional
+        Number of valid correlation pixels to include left and right of the
+        centre.  If omitted, the value from ``half_height`` is used.
+    """
+
+    center_y_img: float
+    center_x_img: float
+    half_height: Annotated[int, Field(ge=0)]
+    half_width: Annotated[int | None, Field(ge=0)] = None
+
+    def get_valid_bounds(
+        self, image_shape: tuple[int, int], template_size: int
+    ) -> tuple[tuple[int, int], tuple[int, int]]:
+        """Return the valid-correlation bounds covered by this window.
+
+        Parameters
+        ----------
+        image_shape : tuple[int, int]
+            Height and width of the micrograph in pixels.
+        template_size : int
+            Width (and height) of the square 2DTM template in pixels.
+
+        Returns
+        -------
+        tuple[tuple[int, int], tuple[int, int]]
+            Inclusive-exclusive bounds in the valid grid for ``(y, x)``
+            coordinates.  The first tuple contains the vertical ``(start, end)``
+            indices and the second contains the horizontal indices.
+
+        Raises
+        ------
+        ValueError
+            If the template does not fit inside the provided image or if the
+            window does not intersect the valid correlation grid.
+        """
+
+        image_height, image_width = image_shape
+        if template_size <= 0:
+            raise ValueError("Template size must be positive.")
+
+        valid_height = image_height - template_size + 1
+        valid_width = image_width - template_size + 1
+
+        if valid_height <= 0 or valid_width <= 0:
+            raise ValueError(
+                "Template size is larger than the micrograph dimensions."
+            )
+
+        resolved_half_width = self.half_width if self.half_width is not None else self.half_height
+
+        template_half = template_size // 2
+        center_y_valid = int(round(self.center_y_img - template_half))
+        center_x_valid = int(round(self.center_x_img - template_half))
+
+        start_valid_y = max(0, center_y_valid - self.half_height)
+        end_valid_y = min(valid_height, center_y_valid + self.half_height + 1)
+        start_valid_x = max(0, center_x_valid - resolved_half_width)
+        end_valid_x = min(valid_width, center_x_valid + resolved_half_width + 1)
+
+        if start_valid_y >= end_valid_y or start_valid_x >= end_valid_x:
+            raise ValueError(
+                "Search window does not overlap the valid correlation grid."
+            )
+
+        return (start_valid_y, end_valid_y), (start_valid_x, end_valid_x)
+
+
+def _dataframe_to_windows(df: pd.DataFrame) -> Iterator[SearchWindow]:
+    """Yield :class:`SearchWindow` objects from a chunk of tabular data."""
+
+    required_columns = {"center_y_img", "center_x_img", "half_height"}
+    missing_columns = required_columns.difference(df.columns)
+    if missing_columns:
+        missing = ", ".join(sorted(missing_columns))
+        raise ValueError(f"Missing required search window columns: {missing}")
+
+    has_half_width = "half_width" in df.columns
+
+    for row in df.itertuples(index=False):
+        half_width_value = getattr(row, "half_width", None) if has_half_width else None
+        half_width: int | None
+        if half_width_value is None:
+            half_width = None
+        elif isinstance(half_width_value, float) and math.isnan(half_width_value):
+            half_width = None
+        else:
+            half_width = int(half_width_value)
+
+        yield SearchWindow(
+            center_y_img=float(row.center_y_img),
+            center_x_img=float(row.center_x_img),
+            half_height=int(row.half_height),
+            half_width=half_width,
+        )
+
+
+def _resolve_table_format(
+    table_path: Path, requested_format: Literal["auto", "csv", "parquet", "feather"]
+) -> Literal["csv", "parquet", "feather"]:
+    """Resolve the tabular format used to describe search windows."""
+
+    if requested_format != "auto":
+        return requested_format
+
+    suffix = table_path.suffix.lower()
+    if suffix in {".csv", ".tsv"}:
+        return "csv"
+    if suffix in {".parquet", ".pq"}:
+        return "parquet"
+    if suffix in {".feather", ".ft"}:
+        return "feather"
+
+    raise ValueError(
+        "Unable to infer search window table format from suffix. "
+        "Specify 'search_window_table_format' explicitly."
+    )
+
+
+def iter_search_windows_from_table(
+    table_path: str | Path,
+    file_format: Literal["auto", "csv", "parquet", "feather"] = "auto",
+    chunk_size: int | None = None,
+) -> Iterator[SearchWindow]:
+    """Stream :class:`SearchWindow` definitions from a tabular source.
+
+    Parameters
+    ----------
+    table_path
+        Path to the CSV/Parquet/Feather file containing window definitions.
+    file_format
+        Override for the file format.  When set to ``"auto"`` (default) the
+        format is inferred from the filename suffix.
+    chunk_size
+        Number of rows to read at a time when streaming CSV input.  Other
+        formats are loaded eagerly as they do not provide chunked readers in
+        pandas.  ``None`` falls back to a default chunk size of 1024 rows.
+
+    Yields
+    ------
+    SearchWindow
+        Parsed window definitions respecting optional ``half_width`` values.
+    """
+
+    path = Path(table_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Search window table '{path}' does not exist.")
+
+    if chunk_size is not None and chunk_size <= 0:
+        raise ValueError("chunk_size must be a positive integer when provided.")
+
+    resolved_format = _resolve_table_format(path, file_format)
+    effective_chunk_size = chunk_size if chunk_size is not None else 1024
+
+    if resolved_format == "csv":
+        csv_iterator = pd.read_csv(path, chunksize=effective_chunk_size)
+        try:
+            for chunk in csv_iterator:
+                if chunk.empty:
+                    continue
+                yield from _dataframe_to_windows(chunk)
+        finally:
+            csv_iterator.close()
+        return
+
+    if resolved_format == "parquet":
+        dataframe = pd.read_parquet(path)
+        if dataframe.empty:
+            return
+        yield from _dataframe_to_windows(dataframe)
+        return
+
+    if resolved_format == "feather":
+        dataframe = pd.read_feather(path)
+        if dataframe.empty:
+            return
+        yield from _dataframe_to_windows(dataframe)
+        return
+
+    raise ValueError(f"Unsupported search window table format '{resolved_format}'.")
+
+
+__all__ = ["SearchWindow", "iter_search_windows_from_table"]
+

--- a/src/leopard_em/pydantic_models/managers/match_template_manager.py
+++ b/src/leopard_em/pydantic_models/managers/match_template_manager.py
@@ -1,13 +1,14 @@
 """Root-level model for serialization and validation of 2DTM parameters."""
 
 import os
-from typing import Any, ClassVar, Literal, Optional
+from typing import Annotated, Any, ClassVar, Iterator, Literal, Optional
 
 import mrcfile
 import pandas as pd
 import torch
-from pydantic import ConfigDict, field_validator
+from pydantic import ConfigDict, Field, field_validator
 
+from leopard_em.analysis.zscore_metric import gaussian_noise_zscore_cutoff
 from leopard_em.backend.core_match_template import core_match_template
 from leopard_em.backend.core_match_template_distributed import (
     core_match_template_distributed,
@@ -20,7 +21,11 @@ from leopard_em.pydantic_models.config import (
     PreprocessingFilters,
 )
 from leopard_em.pydantic_models.custom_types import BaseModel2DTM, ExcludedTensor
-from leopard_em.pydantic_models.data_structures import OpticsGroup
+from leopard_em.pydantic_models.data_structures import (
+    OpticsGroup,
+    SearchWindow,
+    iter_search_windows_from_table,
+)
 from leopard_em.pydantic_models.formats import MATCH_TEMPLATE_DF_COLUMN_ORDER
 from leopard_em.pydantic_models.results import MatchTemplateResult
 from leopard_em.pydantic_models.utils import (
@@ -59,6 +64,23 @@ class MatchTemplateManager(BaseModel2DTM):
         `MatchTemplateResult` class.
     computational_config : ComputationalConfig
         Parameters for controlling computational resources.
+    search_windows : list[SearchWindow], optional
+        Optional regions restricting where the match template search is
+        evaluated.  When omitted, the full micrograph is searched.
+    search_window_table_path : str, optional
+        Path to a tabular file (CSV/Parquet/Feather) enumerating search windows.
+        The file is streamed row-by-row, allowing very large coordinate sets to be
+        processed without loading them entirely into memory.  Providing
+        ``search_windows`` takes precedence over the table path if both are
+        supplied.
+    search_window_table_format : Literal["auto", "csv", "parquet", "feather"]
+        Format override for ``search_window_table_path``.  When set to ``"auto"``
+        (default) the format is inferred from the file suffix.
+    search_window_chunk_size : int, optional
+        Number of rows to load at once when streaming a CSV table.  Other formats
+        are read eagerly.  Defaults to 1024 rows per chunk when unspecified.
+    search_pixel_count : int
+        Number of valid correlation pixels covered by the most recent search.
 
     Methods
     -------
@@ -99,10 +121,15 @@ class MatchTemplateManager(BaseModel2DTM):
     preprocessing_filters: PreprocessingFilters
     match_template_result: MatchTemplateResult
     computational_config: ComputationalConfig
+    search_windows: Optional[list[SearchWindow]] = None
+    search_window_table_path: Optional[str] = None
+    search_window_table_format: Literal["auto", "csv", "parquet", "feather"] = "auto"
+    search_window_chunk_size: Annotated[int | None, Field(gt=0)] = None
 
     # Non-serialized large array-like attributes
     micrograph: ExcludedTensor
     template_volume: ExcludedTensor
+    search_pixel_count: int = Field(default=0, exclude=True)
 
     ###########################
     ### Pydantic Validators ###
@@ -124,6 +151,18 @@ class MatchTemplateManager(BaseModel2DTM):
 
         return str(v)
 
+    @field_validator("search_window_table_path")  # type: ignore
+    def validate_search_window_table_path(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure the optional search window table exists if provided."""
+
+        if v is None:
+            return None
+
+        if not os.path.exists(v):
+            raise ValueError(f"Search window table '{v}' does not exist.")
+
+        return str(v)
+
     def __init__(self, preload_mrc_files: bool = False, **data: Any):
         super().__init__(**data)
 
@@ -136,71 +175,97 @@ class MatchTemplateManager(BaseModel2DTM):
     ### Functional (data processing) methods ###
     ############################################
 
-    def make_backend_core_function_kwargs(self) -> dict[str, Any]:
-        """Generates the keyword arguments for backend call from held parameters."""
-        # Ensure the micrograph and template are loaded and in the correct format
+    def _has_window_source(self) -> bool:
+        """Return ``True`` when a constrained search source is configured."""
+
+        return bool(self.search_windows) or self.search_window_table_path is not None
+
+    def _iter_search_windows(self) -> Iterator[SearchWindow]:
+        """Yield all search windows from either explicit lists or tables."""
+
+        if self.search_windows:
+            yield from self.search_windows
+            return
+
+        if self.search_window_table_path is not None:
+            yield from iter_search_windows_from_table(
+                self.search_window_table_path,
+                file_format=self.search_window_table_format,
+                chunk_size=self.search_window_chunk_size,
+            )
+            return
+
+        raise ValueError("No search windows configured for the constrained search.")
+
+    def _prepare_shared_core_inputs(self) -> dict[str, torch.Tensor]:
+        """Ensure core tensors are loaded and shared across search windows."""
+
         if self.micrograph is None:
             self.micrograph = load_mrc_image(self.micrograph_path)
+        if not isinstance(self.micrograph, torch.Tensor):
+            self.micrograph = torch.from_numpy(self.micrograph)
+        self.micrograph = self.micrograph.to(torch.float32)
+
         if self.template_volume is None:
             self.template_volume = load_mrc_volume(self.template_volume_path)
-
-        # Ensure the micrograph and template are both Tensors before proceeding
-        if not isinstance(self.micrograph, torch.Tensor):
-            image = torch.from_numpy(self.micrograph)
-        else:
-            image = self.micrograph
-
         if not isinstance(self.template_volume, torch.Tensor):
-            template = torch.from_numpy(self.template_volume)
-        else:
-            template = self.template_volume
+            self.template_volume = torch.from_numpy(self.template_volume)
+        self.template_volume = self.template_volume.to(torch.float32)
 
-        # Fourier transform the image (RFFT, unshifted)
-        image_dft = torch.fft.rfftn(image)  # pylint: disable=E1102
-        image_dft[0, 0] = 0 + 0j  # zero out the constant term
+        template_dft = volume_to_rfft_fourier_slice(self.template_volume)
 
-        # Get the bandpass filter individually
+        defocus_values = self.defocus_search_config.defocus_values.to(torch.float32)
+        pixel_size_offsets = torch.tensor([0.0], dtype=torch.float32)
+        ctf_filters = calculate_ctf_filter_stack(
+            template_shape=(self.template_volume.shape[0], self.template_volume.shape[0]),
+            optics_group=self.optics_group,
+            defocus_offsets=defocus_values,
+            pixel_size_offsets=pixel_size_offsets,
+        )
+        euler_angles = self.orientation_search_config.euler_angles.to(torch.float32)
+
+        return {
+            "image": self.micrograph,
+            "template": self.template_volume,
+            "template_dft": template_dft,
+            "defocus_values": defocus_values,
+            "pixel_size_offsets": pixel_size_offsets,
+            "ctf_filters": ctf_filters,
+            "euler_angles": euler_angles,
+        }
+
+    def _make_core_kwargs_for_patch(
+        self,
+        image_patch: torch.Tensor,
+        template: torch.Tensor,
+        template_dft: torch.Tensor,
+        ctf_filters: torch.Tensor,
+        euler_angles: torch.Tensor,
+        defocus_values: torch.Tensor,
+        pixel_size_offsets: torch.Tensor,
+    ) -> dict[str, Any]:
+        """Construct keyword arguments for a specific image patch."""
+
+        image_dft = torch.fft.rfftn(image_patch)
+        image_dft[0, 0] = 0 + 0j
+
         bp_config = self.preprocessing_filters.bandpass_filter
         bandpass_filter = bp_config.calculate_bandpass_filter(image_dft.shape)
 
-        # Calculate the cumulative filters for both the image and the template.
         cumulative_filter_image = self.preprocessing_filters.get_combined_filter(
             ref_img_rfft=image_dft,
             output_shape=image_dft.shape,
         )
-        # NOTE: Here, manually accounting for the RFFT in output shape since we have not
-        # RFFT'd the template volume yet. Also, this is 2-dimensional, not 3-dimensional
         cumulative_filter_template = self.preprocessing_filters.get_combined_filter(
             ref_img_rfft=image_dft,
             output_shape=(template.shape[-2], template.shape[-1] // 2 + 1),
         )
 
-        # Apply the pre-processing and normalization
         image_preprocessed_dft = preprocess_image(
             image_rfft=image_dft,
             cumulative_fourier_filters=cumulative_filter_image,
             bandpass_filter=bandpass_filter,
         )
-
-        # Calculate the CTF filters at each defocus value
-        defocus_values = self.defocus_search_config.defocus_values
-
-        # set pixel search to 0.0 for match template
-        pixel_size_offsets = torch.tensor([0.0], dtype=torch.float32)
-
-        ctf_filters = calculate_ctf_filter_stack(
-            template_shape=(template.shape[0], template.shape[0]),
-            optics_group=self.optics_group,
-            defocus_offsets=defocus_values,
-            pixel_size_offsets=pixel_size_offsets,
-        )
-
-        # Grab the Euler angles from the orientation search configuration
-        # (phi, theta, psi) for ZYZ convention
-        euler_angles = self.orientation_search_config.euler_angles
-        euler_angles = euler_angles.to(torch.float32)
-
-        template_dft = volume_to_rfft_fourier_slice(template)
 
         return {
             "image_dft": image_preprocessed_dft,
@@ -212,6 +277,160 @@ class MatchTemplateManager(BaseModel2DTM):
             "pixel_values": pixel_size_offsets,
             "device": self.computational_config.gpu_devices,
         }
+
+    def make_backend_core_function_kwargs(self) -> dict[str, Any]:
+        """Generates the keyword arguments for backend call from held parameters."""
+        shared_inputs = self._prepare_shared_core_inputs()
+
+        return self._make_core_kwargs_for_patch(
+            image_patch=shared_inputs["image"],
+            template=shared_inputs["template"],
+            template_dft=shared_inputs["template_dft"],
+            ctf_filters=shared_inputs["ctf_filters"],
+            euler_angles=shared_inputs["euler_angles"],
+            defocus_values=shared_inputs["defocus_values"],
+            pixel_size_offsets=shared_inputs["pixel_size_offsets"],
+        )
+
+    # pylint: disable=too-many-locals
+    def _run_match_template_with_windows(
+        self,
+        orientation_batch_size: int,
+        do_result_export: bool,
+        do_valid_cropping: bool,
+    ) -> None:
+        """Run match template within user-specified spatial windows."""
+
+        if not self._has_window_source():
+            raise ValueError(
+                "No search windows configured. Provide 'search_windows' or "
+                "'search_window_table_path' in the configuration."
+            )
+
+        shared_inputs = self._prepare_shared_core_inputs()
+        image = shared_inputs["image"]
+        template = shared_inputs["template"]
+        template_size = int(template.shape[-1])
+
+        image_height, image_width = int(image.shape[-2]), int(image.shape[-1])
+        valid_height = image_height - template_size + 1
+        valid_width = image_width - template_size + 1
+        if valid_height <= 0 or valid_width <= 0:
+            raise ValueError("Template dimensions exceed the micrograph size.")
+
+        dtype = torch.float32
+        mip_valid = torch.full((valid_height, valid_width), float("-inf"), dtype=dtype)
+        scaled_mip_valid = torch.full((valid_height, valid_width), float("-inf"), dtype=dtype)
+        corr_mean_valid = torch.zeros((valid_height, valid_width), dtype=dtype)
+        corr_var_valid = torch.zeros((valid_height, valid_width), dtype=dtype)
+        psi_valid = torch.zeros((valid_height, valid_width), dtype=dtype)
+        theta_valid = torch.zeros((valid_height, valid_width), dtype=dtype)
+        phi_valid = torch.zeros((valid_height, valid_width), dtype=dtype)
+        defocus_valid = torch.zeros((valid_height, valid_width), dtype=dtype)
+        search_mask = torch.zeros((valid_height, valid_width), dtype=torch.bool)
+
+        total_projections = 0
+        total_orientations = 0
+        total_defocus = 0
+
+        for window in self._iter_search_windows():
+            valid_y_bounds, valid_x_bounds = window.get_valid_bounds(
+                (image_height, image_width), template_size
+            )
+            start_valid_y, end_valid_y = valid_y_bounds
+            start_valid_x, end_valid_x = valid_x_bounds
+
+            start_img_y = start_valid_y
+            end_img_y = end_valid_y + template_size - 1
+            start_img_x = start_valid_x
+            end_img_x = end_valid_x + template_size - 1
+
+            image_patch = image[start_img_y:end_img_y, start_img_x:end_img_x].contiguous()
+
+            core_kwargs = self._make_core_kwargs_for_patch(
+                image_patch=image_patch,
+                template=template,
+                template_dft=shared_inputs["template_dft"],
+                ctf_filters=shared_inputs["ctf_filters"],
+                euler_angles=shared_inputs["euler_angles"],
+                defocus_values=shared_inputs["defocus_values"],
+                pixel_size_offsets=shared_inputs["pixel_size_offsets"],
+            )
+
+            results = core_match_template(
+                **core_kwargs,
+                orientation_batch_size=orientation_batch_size,
+                num_cuda_streams=self.computational_config.num_cpus,
+            )
+
+            patch_height_valid = end_valid_y - start_valid_y
+            patch_width_valid = end_valid_x - start_valid_x
+            valid_slice = (slice(0, patch_height_valid), slice(0, patch_width_valid))
+
+            mip_valid[start_valid_y:end_valid_y, start_valid_x:end_valid_x] = (
+                results["mip"][valid_slice].cpu()
+            )
+            scaled_mip_valid[start_valid_y:end_valid_y, start_valid_x:end_valid_x] = (
+                results["scaled_mip"][valid_slice].cpu()
+            )
+            corr_mean_valid[start_valid_y:end_valid_y, start_valid_x:end_valid_x] = (
+                results["correlation_mean"][valid_slice].cpu()
+            )
+            corr_var_valid[start_valid_y:end_valid_y, start_valid_x:end_valid_x] = (
+                results["correlation_variance"][valid_slice].cpu()
+            )
+            psi_valid[start_valid_y:end_valid_y, start_valid_x:end_valid_x] = (
+                results["best_psi"][valid_slice].cpu()
+            )
+            theta_valid[start_valid_y:end_valid_y, start_valid_x:end_valid_x] = (
+                results["best_theta"][valid_slice].cpu()
+            )
+            phi_valid[start_valid_y:end_valid_y, start_valid_x:end_valid_x] = (
+                results["best_phi"][valid_slice].cpu()
+            )
+            defocus_valid[start_valid_y:end_valid_y, start_valid_x:end_valid_x] = (
+                results["best_defocus"][valid_slice].cpu()
+            )
+
+            search_mask[start_valid_y:end_valid_y, start_valid_x:end_valid_x] = True
+
+            total_projections = results["total_projections"]
+            total_orientations = results["total_orientations"]
+            total_defocus = results["total_defocus"]
+
+        searched_pixels = int(search_mask.sum().item())
+        if searched_pixels == 0:
+            raise ValueError("Search windows did not cover any valid pixels.")
+
+        self.search_pixel_count = searched_pixels
+
+        prevalid_shape = (image_height, image_width)
+
+        def _embed_valid_map(valid_map: torch.Tensor, fill_value: float = 0.0) -> torch.Tensor:
+            embedded = torch.full(prevalid_shape, fill_value, dtype=valid_map.dtype)
+            embedded[:valid_height, :valid_width] = valid_map
+            return embedded
+
+        results_combined = {
+            "mip": _embed_valid_map(mip_valid, fill_value=float("-inf")),
+            "scaled_mip": _embed_valid_map(scaled_mip_valid, fill_value=float("-inf")),
+            "correlation_mean": _embed_valid_map(corr_mean_valid, fill_value=0.0),
+            "correlation_variance": _embed_valid_map(corr_var_valid, fill_value=0.0),
+            "best_psi": _embed_valid_map(psi_valid, fill_value=0.0),
+            "best_theta": _embed_valid_map(theta_valid, fill_value=0.0),
+            "best_phi": _embed_valid_map(phi_valid, fill_value=0.0),
+            "best_defocus": _embed_valid_map(defocus_valid, fill_value=0.0),
+            "total_projections": total_projections,
+            "total_orientations": total_orientations,
+            "total_defocus": total_defocus,
+        }
+
+        self.match_template_result.match_template_peaks = None
+        self._populate_match_template_result(
+            results_combined,
+            do_result_export=do_result_export,
+            do_valid_cropping=do_valid_cropping,
+        )
 
     def run_match_template(
         self,
@@ -235,6 +454,15 @@ class MatchTemplateManager(BaseModel2DTM):
         -------
         None
         """
+        if self._has_window_source():
+            self._run_match_template_with_windows(
+                orientation_batch_size=orientation_batch_size,
+                do_result_export=do_result_export,
+                do_valid_cropping=do_valid_cropping,
+            )
+            return
+
+        self.search_pixel_count = 0
         core_kwargs = self.make_backend_core_function_kwargs()
         results = core_match_template(
             **core_kwargs,
@@ -248,6 +476,7 @@ class MatchTemplateManager(BaseModel2DTM):
             do_result_export=do_result_export,
             do_valid_cropping=do_valid_cropping,
         )
+        self.search_pixel_count = int(self.match_template_result.mip.numel())
 
     def run_match_template_distributed(
         self,
@@ -285,6 +514,11 @@ class MatchTemplateManager(BaseModel2DTM):
         -------
         None
         """
+        if self._has_window_source():
+            raise NotImplementedError(
+                "Constrained search windows are not currently supported in distributed runs."
+            )
+
         if not torch.distributed.is_initialized():
             raise RuntimeError(
                 "Distributed process group has not been initialized! "
@@ -386,11 +620,26 @@ class MatchTemplateManager(BaseModel2DTM):
             DataFrame containing the match template results.
         """
         # Short circuit if no kwargs and peaks have already been located
-        if locate_peaks_kwargs is None:
+        locate_kwargs = dict(locate_peaks_kwargs) if locate_peaks_kwargs else {}
+
+        if self.search_windows and "z_score_cutoff" not in locate_kwargs:
+            search_pixels = self.search_pixel_count
+            if search_pixels <= 0:
+                search_pixels = int(self.match_template_result.mip.numel())
+            false_positives = locate_kwargs.get("false_positives", 1.0)
+            total_correlations = max(1, search_pixels) * max(
+                1, self.match_template_result.total_projections
+            )
+            locate_kwargs["z_score_cutoff"] = gaussian_noise_zscore_cutoff(
+                num_ccg=total_correlations,
+                false_positives=false_positives,
+            )
+
+        if not locate_kwargs:
             if self.match_template_result.match_template_peaks is None:
                 self.match_template_result.locate_peaks()
         else:
-            self.match_template_result.locate_peaks(**locate_peaks_kwargs)
+            self.match_template_result.locate_peaks(**locate_kwargs)
 
         # DataFrame comes with the following columns :
         # ['mip', 'scaled_mip', 'correlation_mean', 'correlation_variance',

--- a/tests/pydantic_models/test_search_window.py
+++ b/tests/pydantic_models/test_search_window.py
@@ -1,0 +1,92 @@
+"""Tests for the SearchWindow utility class."""
+
+import pandas as pd
+import pytest
+
+from leopard_em.pydantic_models.data_structures import (
+    SearchWindow,
+    iter_search_windows_from_table,
+)
+
+
+def test_search_window_basic_bounds() -> None:
+    """Search window returns expected valid-grid bounds away from edges."""
+
+    window = SearchWindow(center_y_img=100.0, center_x_img=120.0, half_height=5, half_width=8)
+    bounds_y, bounds_x = window.get_valid_bounds(image_shape=(200, 220), template_size=20)
+
+    assert bounds_y == (85, 96)
+    assert bounds_x == (102, 119)
+
+
+def test_search_window_clamps_to_edges() -> None:
+    """Bounds are clamped to the valid grid when the window touches image edges."""
+
+    window = SearchWindow(center_y_img=8.0, center_x_img=8.0, half_height=3)
+    bounds_y, bounds_x = window.get_valid_bounds(image_shape=(40, 40), template_size=20)
+
+    assert bounds_y == (0, 2)
+    assert bounds_x == (0, 2)
+
+
+def test_search_window_raises_for_invalid_region() -> None:
+    """A ValueError is raised when the window does not intersect valid pixels."""
+
+    window = SearchWindow(center_y_img=0.0, center_x_img=0.0, half_height=0)
+
+    with pytest.raises(ValueError):
+        window.get_valid_bounds(image_shape=(32, 32), template_size=28)
+
+
+def test_iter_search_windows_from_table_streams_csv(tmp_path) -> None:
+    """CSV window tables are streamed in chunks and parsed correctly."""
+
+    df = pd.DataFrame(
+        {
+            "center_y_img": [5.0, 10.5, 42.2],
+            "center_x_img": [7.0, 11.5, 44.8],
+            "half_height": [2, 3, 4],
+            "half_width": [1, None, 6],
+        }
+    )
+    table_path = tmp_path / "windows.csv"
+    df.to_csv(table_path, index=False)
+
+    windows = list(iter_search_windows_from_table(table_path, chunk_size=2))
+
+    assert len(windows) == 3
+    assert windows[0].half_width == 1
+    assert windows[1].half_width is None
+    assert windows[2].half_height == 4
+
+
+def test_iter_search_windows_from_table_requires_columns(tmp_path) -> None:
+    """Missing required columns raise a ValueError during iteration."""
+
+    df = pd.DataFrame({"center_y_img": [1.0], "center_x_img": [2.0]})
+    table_path = tmp_path / "bad.csv"
+    df.to_csv(table_path, index=False)
+
+    iterator = iter_search_windows_from_table(table_path)
+
+    with pytest.raises(ValueError):
+        next(iterator)
+
+
+def test_iter_search_windows_from_table_validates_chunk_size(tmp_path) -> None:
+    """Zero chunk size is rejected to avoid infinite loops."""
+
+    df = pd.DataFrame(
+        {
+            "center_y_img": [1.0],
+            "center_x_img": [2.0],
+            "half_height": [1],
+        }
+    )
+    table_path = tmp_path / "windows.csv"
+    df.to_csv(table_path, index=False)
+
+    iterator = iter_search_windows_from_table(table_path, chunk_size=0)
+
+    with pytest.raises(ValueError):
+        next(iterator)


### PR DESCRIPTION
## Summary
- add a streaming loader for search windows so match-template can pull coordinates from CSV/Parquet/Feather tables with configurable chunk sizes
- extend the manager, documentation, and example configuration to cover the new tabular workflow while keeping explicit window lists supported
- cover the helper with pytest cases that validate chunking, column requirements, and optional half-width handling

## Testing
- PYTHONPATH=src pytest tests/pydantic_models/test_search_window.py

------
https://chatgpt.com/codex/tasks/task_e_68cfa3d9c2bc8329b3fa5d30fb3ff1d2